### PR TITLE
Fixes `ERR_LOADER_CHAIN_INCOMPLETE`

### DIFF
--- a/src/resolve-hook.mjs
+++ b/src/resolve-hook.mjs
@@ -8,7 +8,7 @@ import {resolve as resolveWithEsBuild, getFormat as getFormatWithEsBuild, load a
 
 export async function resolve(specifier, context, defaultResolver) {
     if (specifier === PATH_URL) {
-        return Promise.resolve({url: specifier});
+        return Promise.resolve({url: specifier, shortCircuit: true});
     }
     const resolution = await resolveWithEsBuild(specifier, context, defaultResolver);
     if (global.ImportTrackingConfig) {
@@ -18,7 +18,7 @@ export async function resolve(specifier, context, defaultResolver) {
         }
     }
 
-    return Promise.resolve(resolution);
+    return Promise.resolve(Object.assign(resolution, {shortCircuit: true}));
 }
 
 export function getFormat(url, context, defaultFormat) {
@@ -54,11 +54,11 @@ export function getSource(url, context, defaultGetSource) {
 // See: https://github.com/nodejs/node/pull/37468
 export function load(url, context, defaultLoad) {
     if (url === PATH_URL) {
-        return {format: PATHS_MODULE_FORMAT, source: importedPathsSource(importedPaths)};
+        return {format: PATHS_MODULE_FORMAT, source: importedPathsSource(importedPaths), shortCircuit: true};
     } else {
         if (forceESM(global.ImportTrackingConfig, url)) {
             context.format = "module";
         }
-        return loadEsBuild(url, context, defaultLoad);
+        return Object.assign(loadEsBuild(url, context, defaultLoad), {shortCircuit: true});
     }
 }


### PR DESCRIPTION
Adds `{shortCircute: true}` to the return values of `resolve` and `load` to fix the `ERR_LOADER_CHAIN_INCOMPLETE` error I was getting when using node >= v16.17.0 || v18.6.0

```
Error [ERR_LOADER_CHAIN_INCOMPLETE]: "/Users/ibeckermayer/beamer.chat/hydrogen-web/node_modules/impunity/src/resolve-hook.mjs 'resolve'" did not call the next hook in its chain and did not explicitly signal a short circuit. If this is intentional, include `shortCircuit: true` in the hook's return.
    at new NodeError (node:internal/errors:393:5)
    at ESMLoader.resolve (node:internal/modules/esm/loader:849:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:7)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:530:24)
    at async findProjectImports (file:///Users/ibeckermayer/beamer.chat/hydrogen-web/node_modules/impunity/src/discover.mjs:13:22)
    at async findTests (file:///Users/ibeckermayer/beamer.chat/hydrogen-web/node_modules/impunity/src/discover.mjs:64:14)
    at async main (file:///Users/ibeckermayer/beamer.chat/hydrogen-web/node_modules/impunity/src/main.mjs:20:16) {
  code: 'ERR_LOADER_CHAIN_INCOMPLETE'
}
✨  Done in 1.60s.
```

See documentation [here](https://nodejs.org/api/esm.html#hooks) for more info.